### PR TITLE
adding into the docker cmd --detach=true as its needed to keep the conta...

### DIFF
--- a/lib/chef_metal_docker/docker_transport.rb
+++ b/lib/chef_metal_docker/docker_transport.rb
@@ -52,7 +52,7 @@ module ChefMetalDocker
       live_stream = nil
       live_stream = STDOUT if options[:stream]
       live_stream = options[:stream_stdout] if options[:stream_stdout]
-      cmd = Mixlib::ShellOut.new(Shellwords.join(['docker', 'run', '--name', container_name, @image.id ] + command),
+      cmd = Mixlib::ShellOut.new(Shellwords.join(['docker', 'run', '--detach=true', '--name', container_name, @image.id ] + command),
         :live_stream => live_stream, :timeout => execute_timeout(options))
 
       Chef::Log.debug("Executing #{cmd}")


### PR DESCRIPTION
...iner from running in stdout and causing chef-client to hang
