### PR TITLE
breaking here caused issue 38 for me because buffers werent flushed

### DIFF
--- a/lib/chef/provisioning/docker_driver/chef_zero_http_proxy.rb
+++ b/lib/chef/provisioning/docker_driver/chef_zero_http_proxy.rb
@@ -79,7 +79,6 @@ class ChefZeroHttpProxy
     loop do
       to_server.read(8192, buff)
       to_client.write(buff)
-      break if buff.size < 8192
     end
 
     # Close the sockets


### PR DESCRIPTION
I had the same error as in #38 and tracked it down to being this break. I think that having a break here prevents the buffer from being read when the buffer isn't a complete multiple of 8192. Commenting out this line fixed the issue for me.
