### PR TITLE
leverage exec for transport and implements connect_to_machine and stop_machine

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,16 +15,3 @@ spec/reports
 test/tmp
 test/version_tmp
 tmp
-*.bundle
-*.so
-*.o
-*.a
-mkmf.log
-*.sw*
-clients
-nodes
-docs/examples/clients
-docs/examples/nodes
-docs/examples/data_bags
-x.rb
-.idea/

--- a/README.md
+++ b/README.md
@@ -72,8 +72,8 @@ This  supports the new machine image paradigm; with Docker you can build a base 
 ```ruby
 require 'chef/provisioning/docker_driver'
 
-machine_image 'web_server' do
-  recipe 'apache'
+machine_image 'ssh_server' do
+  recipe 'openssh'
 
   machine_options :docker_options => {
       :base_image => {
@@ -84,11 +84,12 @@ machine_image 'web_server' do
   }
 end
 
-machine 'web00' do
-  from_image 'web_server'
+machine 'ssh00' do
+  from_image 'ssh_server'
 
   machine_options :docker_options => {
-      :command => '/usr/sbin/httpd'
+      :command => '/usr/sbin/sshd -D -o UsePAM=no -o UsePrivilegeSeparation=no -o PidFile=/tmp/sshd.pid',
+      :ports => [22]
   }
 end
 ```

--- a/lib/chef/provisioning/docker_driver/driver.rb
+++ b/lib/chef/provisioning/docker_driver/driver.rb
@@ -70,9 +70,11 @@ module DockerDriver
       end
     end
 
-
     def allocate_machine(action_handler, machine_spec, machine_options)
-      machine_spec.from_image = action_handler.provider.new_resource.from_image
+      machine_spec.from_image = from_image_from_action_handler(
+        action_handler,
+        machine_spec
+      )
       docker_options = machine_options[:docker_options]
       container_id = nil
       image_id = machine_options[:image_id]
@@ -265,6 +267,17 @@ module DockerDriver
       machine_spec.reference['image_id'] = image.id if image
 
       image
+    end
+
+    def from_image_from_action_handler(action_handler, machine_spec)
+      case action_handler
+      when Chef::Provisioning::AddPrefixActionHandler
+        machines = action_handler.action_handler.provider.new_resource.machines
+        this_machine = machines.select { |m| m.name == machine_spec.name}.first
+        this_machine.from_image
+      else
+        action_handler.provider.new_resource.from_image
+      end
     end
 
     def driver_url

--- a/lib/chef/provisioning/docker_driver/driver.rb
+++ b/lib/chef/provisioning/docker_driver/driver.rb
@@ -72,64 +72,112 @@ module DockerDriver
 
 
     def allocate_machine(action_handler, machine_spec, machine_options)
+      machine_spec.from_image = action_handler.provider.new_resource.from_image
+      docker_options = machine_options[:docker_options]
+      container_id = nil
+      image_id = machine_options[:image_id]
+      if machine_spec.reference
+        container_name = machine_spec.reference['container_name']
+        container_id = machine_spec.reference['container_id']
+        image_id ||= machine_spec.reference['image_id']
+        docker_options ||= machine_spec.reference['docker_options']
+      end
 
-      container_name = machine_spec.name
+      container_name ||= machine_spec.name
       machine_spec.reference = {
-          'driver_url' => driver_url,
-          'driver_version' => Chef::Provisioning::DockerDriver::VERSION,
-          'allocated_at' => Time.now.utc.to_s,
-          'host_node' => action_handler.host_node,
-          'container_name' => container_name,
-          'image_id' => machine_options[:image_id],
-          'docker_options' => machine_options[:docker_options]
+        'driver_url' => driver_url,
+        'driver_version' => Chef::Provisioning::DockerDriver::VERSION,
+        'allocated_at' => Time.now.utc.to_s,
+        'host_node' => action_handler.host_node,
+        'container_name' => container_name,
+        'image_id' => image_id,
+        'docker_options' => docker_options,
+        'container_id' => container_id
       }
+      build_container(machine_spec, docker_options)
     end
 
     def ready_machine(action_handler, machine_spec, machine_options)
-      base_image_name = build_container(machine_spec, machine_options)
-      start_machine(action_handler, machine_spec, machine_options, base_image_name)
-      machine_for(machine_spec, machine_options, base_image_name)
+      start_machine(action_handler, machine_spec, machine_options)
+      machine_for(machine_spec, machine_options)
     end
 
-    def build_container(machine_spec, machine_options)
-      docker_options = machine_options[:docker_options]
+    def build_container(machine_spec, docker_options)
+      container = container_for(machine_spec)
+      return container unless container.nil?
 
-      base_image = docker_options[:base_image]
-      if !base_image
-        Chef::Log.debug("No base images specified in docker options.")
-        base_image = base_image_for(machine_spec)
+      image = find_image(machine_spec) ||
+        build_image(machine_spec, docker_options)
+
+      args = [
+        'docker',
+        'run',
+        '--name',
+        machine_spec.reference['container_name'],
+        '--detach'
+      ]
+
+      if docker_options[:keep_stdin_open]
+        args << '-i'
       end
+
+      if docker_options[:env]      
+        docker_options[:env].each do |key, value|
+          args << '-e'
+          args << "#{key}=#{value}"
+        end
+      end
+
+      if docker_options[:ports]
+        docker_options[:ports].each do |portnum|
+          args << '-p'
+          args << "#{portnum}"
+        end
+      end
+
+      if docker_options[:volumes]
+        docker_options[:volumes].each do |volume|
+          args << '-v'
+          args << "#{volume}"
+        end
+      end
+
+      args << image.id
+      args += Shellwords.split("/bin/sh -c 'while true;do sleep 1; done'")
+
+      cmdstr = Shellwords.join(args)
+      Chef::Log.debug("Executing #{cmdstr}")
+
+      cmd = Mixlib::ShellOut.new(cmdstr)
+      cmd.run_command
+
+      container = Docker::Container.get(machine_spec.reference['container_name'])
+
+      Chef::Log.debug("Container id: #{container.id}")
+      machine_spec.reference['container_id'] = container.id
+      container
+    end
+
+    def build_image(machine_spec, docker_options)
+      base_image = docker_options[:base_image] || base_image_for(machine_spec)
       source_name = base_image[:name]
       source_repository = base_image[:repository]
       source_tag = base_image[:tag]
 
-      # Don't do this if we're loading from an image
-      if docker_options[:from_image]
-        "#{source_repository}:#{source_tag}"
-      else
-        target_repository = 'chef'
-        target_tag = machine_spec.name
+      target_tag = machine_spec.reference['container_name']
 
-        # check if target image exists, if not try to look up for source image.
-        image = find_image(target_repository, target_tag) || find_image(source_repository, source_tag)
+      image = Docker::Image.create(
+        'fromImage' => source_name,
+        'repo' => source_repository,
+        'tag' => source_tag
+      )
+      
+      Chef::Log.debug("Allocated #{image}")
+      image.tag('repo' => 'chef', 'tag' => target_tag)
+      Chef::Log.debug("Tagged image #{image}")
 
-        # kick off image creation
-        if image == nil
-          Chef::Log.debug("No matching images for #{target_repository}:#{target_tag}, creating!")
-          image = Docker::Image.create('fromImage' => source_name,
-                                       'repo' => source_repository ,
-                                       'tag' => source_tag)
-          Chef::Log.debug("Allocated #{image}")
-          image.tag('repo' => 'chef', 'tag' => target_tag)
-          Chef::Log.debug("Tagged image #{image}")
-        elsif not image.info['RepoTags'].include? "#{target_repository}:#{target_tag}"
-          # if `find_image(source_repository, source_tag)` returned result, assign target tag to it to be able
-          # find it in `start_machine`.
-          image.tag('repo' => target_repository, 'tag' => target_tag)
-        end
-
-        "#{target_repository}:#{target_tag}"
-      end
+      machine_spec.reference['image_id'] = image.id
+      image
     end
 
     def allocate_image(action_handler, image_spec, image_options, machine_spec, machine_options)
@@ -163,101 +211,101 @@ module DockerDriver
 
     # Connect to machine without acquiring it
     def connect_to_machine(machine_spec, machine_options)
-      Chef::Log.debug('Connect to machine!')
+      Chef::Log.debug('Connect to machine')
+      machine_for(machine_spec, machine_options)
     end
 
     def destroy_machine(action_handler, machine_spec, machine_options)
-      container_name = machine_spec.location['container_name']
-      Chef::Log.debug("Destroying container: #{container_name}")
-      container = Docker::Container.get(container_name, @connection)
-
-      begin
-        Chef::Log.debug("Stopping #{container_name}")
-        container.stop
-      rescue Excon::Errors::NotModified
-        # this is okay
-        Chef::Log.debug('Already stopped!')
+      container = container_for(machine_spec)
+      if container
+        Chef::Log.debug("Destroying container: #{container.id}")
+        container.delete(:force => true)
       end
 
-      Chef::Log.debug("Removing #{container_name}")
-      container.delete
-
       if !machine_spec.attrs[:keep_image] && !machine_options[:keep_image]
-        Chef::Log.debug("Destroying image: chef:#{container_name}")
-        image = Docker::Image.get("chef:#{container_name}")
+        image = find_image(machine_spec)
+        Chef::Log.debug("Destroying image: chef:#{image.id}")
         image.delete
       end
     end
 
-    def stop_machine(action_handler, node)
-      Chef::Log.debug("Stop machine: #{node.inspect}")
+    def stop_machine(action_handler, machine_spec, machine_options)
+      container = container_for(machine_spec)
+      return if container.nil?
+
+      container.stop if container.info['State']['Running']
     end
 
-    def image_named(image_name)
-      Docker::Image.all.select {
-          |i| i.info['RepoTags'].include? image_name
-      }.first
-    end
+    def find_image(machine_spec)
+      image = nil
 
-    def find_image(repository, tag)
-      Docker::Image.all.select {
-          |i| i.info['RepoTags'].include? "#{repository}:#{tag}"
-      }.first
+      if machine_spec.reference['image_id']
+        begin
+          image = Docker::Image.get(machine_spec.reference['image_id'])
+        rescue Docker::Error::NotFoundError
+        end
+      end
+
+      if image.nil?
+        image_name = "chef:#{machine_spec.reference['container_name']}"
+        if machine_spec.from_image
+          base_image = base_image_for(machine_spec)
+          image_name = "#{base_image[:repository]}:#{base_image[:tag]}"
+        end
+
+        image = Docker::Image.all.select {
+            |i| i.info['RepoTags'].include? image_name
+        }.first
+
+        if machine_spec.from_image && image.nil?
+          raise "Unable to locate machine_image for #{image_name}"
+        end
+      end
+
+      machine_spec.reference['image_id'] = image.id if image
+
+      image
     end
 
     def driver_url
       "docker:#{Docker.url}"
     end
 
-    def start_machine(action_handler, machine_spec, machine_options, base_image_name)
-      # Spin up a docker instance if needed, otherwise use the existing one
-      container_name = machine_spec.location['container_name']
+    def start_machine(action_handler, machine_spec, machine_options)
+      container = container_for(machine_spec)
+      if container && !container.info['State']['Running']
+        container.start
+      end
+    end
 
-      begin
-        Docker::Container.get(container_name, @connection)
-      rescue Docker::Error::NotFoundError
-        docker_options = machine_options[:docker_options]
-        Chef::Log.debug("Start machine for container #{container_name} using base image #{base_image_name} with options #{docker_options.inspect}")
-        image = image_named(base_image_name)
-        container = Docker::Container.create('Image' => image.id, 'name' => container_name)
-        Chef::Log.debug("Container id: #{container.id}")
-        machine_spec.location['container_id'] = container.id
+    def machine_for(machine_spec, machine_options)
+      Chef::Log.debug('machine_for...')
+      docker_options = machine_options[:docker_options] || Mash.from_hash(machine_spec.reference['docker_options'])
+
+      container = Docker::Container.get(machine_spec.reference['container_id'], @connection)
+
+      if machine_spec.from_image
+        convergence_strategy = Chef::Provisioning::ConvergenceStrategy::NoConverge.new({}, config)
+      else
+        convergence_strategy = Chef::Provisioning::ConvergenceStrategy::InstallCached.
+          new(machine_options[:convergence_options], config)
       end
 
+      transport = DockerTransport.new(container, config)
+
+      Chef::Provisioning::DockerDriver::DockerContainerMachine.new(
+        machine_spec,
+        transport,
+        convergence_strategy,
+        docker_options[:command]
+      )
     end
 
-    def machine_for(machine_spec, machine_options, base_image_name)
-      Chef::Log.debug('machine_for...')
-
-      docker_options = machine_options[:docker_options]
-
-      transport = DockerTransport.new(machine_spec.location['container_name'],
-                                      base_image_name,
-                                      nil,
-                                      Docker.connection)
-
-      convergence_strategy = if docker_options[:from_image]
-                               Chef::Provisioning::ConvergenceStrategy::NoConverge.new({}, config)
-                             else
-                               convergence_strategy_for(machine_spec, machine_options)
-                             end
-
-        Chef::Provisioning::DockerDriver::DockerContainerMachine.new(
-          machine_spec,
-          transport,
-          convergence_strategy,
-          :command => docker_options[:command],
-          :env => docker_options[:env],
-          :ports => Array(docker_options[:ports]),
-          :volumes => Array(docker_options[:volumes]),
-          :keep_stdin_open => docker_options[:keep_stdin_open]
-        )
-    end
-
-    def convergence_strategy_for(machine_spec, machine_options)
-      @unix_convergence_strategy ||= begin
-        Chef::Provisioning::ConvergenceStrategy::InstallCached.
-            new(machine_options[:convergence_options], config)
+    def container_for(machine_spec)
+      container_id = machine_spec.reference['container_id']
+      begin
+        container = Docker::Container.get(container_id, @connection) if container_id
+      rescue Docker::Error::NotFoundError
       end
     end
 


### PR DESCRIPTION
This PR simplifies reconverging and changing the state of running containers by levereging `exec` in the transport. It also implements `connect_to_machine` and thus allows one to use the `machine_execute` and `machine_file` resources on docker containers.

This ended up being bringing in some fairly deep changes so here are some implementation notes:
- Removes the `Gemfile.lock` and adds basic entries to the empty `.gitignore` file to provide a better dev experience.
- Replaces the apache based `readme` example with the `ssh_server` cookbook. Currently the apache example fails to start the container. The `apache::default` recipe is empty and the command `/usr/sbin/httpd` is not applicable to the `ubuntu` base image used. Even using `/usr/sbin/apache2` and the `apache2::default` cookbook had some config errors. The `ssh_server` cookbook just worked and results in a running container.
- There was a fair amount of "dead code" in the transport that I deleted. It was called by the `execute_old` code deleted over a year ago and I found it added confusion to the class.
- Much of the initial container port, volume, etc. setup is moved to the driver and is now a one-time operation done in `machine_allocate` and simple runs a vanilla bash loop as suggested by @marc- . `machine_allocate` now creates the container but it is "unconverged" and not running the final command. However it does have the ports, volumes, etc properly configured.
- So the transport now just delegates to `Docker::Container.exec`
- Writes to the container writes to the container mount usually located in `/var/lib/docker`
- This now streams stdout/err similar to most of the other drivers using `stream_chunk`
- The `docker_container_machine` commits images after convergence and if the command has changed, starts a new container
- Container and image lookups now prefer IDs and the implementation ensures these are kept in alignment with the machine/image spec.

One thing that is a definite hack and I think is due to a bug in chef-provisioning is this line in `allocate_machine`: 

```
machine_spec.from_image = action_handler.provider.new_resource.from_image
```

`from_image` is not set in the provider until after the call to `allocate_machine`

I'll submit a separate PR to chef-provisioning to address tis unless someone thinks this is necessary.
