### PR TITLE
using TCP socket to transfer files between containers instead of copy

### DIFF
--- a/lib/chef/provisioning/docker_driver/docker_transport.rb
+++ b/lib/chef/provisioning/docker_driver/docker_transport.rb
@@ -91,7 +91,7 @@ module DockerDriver
         if execute("which ruby").exitstatus == 0
           res = execute("ruby -e \"require 'socket'; s = TCPSocket.new('#{ip}', #{port}); File.open('#{path}', 'w') { |f| f.write s.read }; s.close\"").exitstatus
         else
-          res = execute("sh -c 'nc -v -q1 #{ip} #{port} > #{path} 2>/tmp/nc_error'").exitstatus
+          res = execute("curl -o #{path} telnet://#{ip}:#{port}").exitstatus
         end
       end
       server.close

--- a/lib/chef/provisioning/docker_driver/docker_transport.rb
+++ b/lib/chef/provisioning/docker_driver/docker_transport.rb
@@ -91,7 +91,7 @@ module DockerDriver
         if execute("which ruby").exitstatus == 0
           res = execute("ruby -e \"require 'socket'; s = TCPSocket.new('#{ip}', #{port}); File.open('#{path}', 'w') { |f| f.write s.read }; s.close\"").exitstatus
         else
-          res = execute("curl -o #{path} telnet://#{ip}:#{port}").exitstatus
+          res = execute("sh -c 'nc -v -q1 #{ip} #{port} > #{path} 2>/tmp/nc_error'").exitstatus
         end
       end
       server.close


### PR DESCRIPTION
This is a naive implementation of a way to transfer files which does not require to have access to /proc pseudo file system.
Basically it:
1. launches a TCP server on an available port
2. mkdir the basedir of the file to copy
3. reads the file from the server either with netcat or with ruby if it is available 
4. writes the contents of the file to the destination path
