### PR TITLE
Replace FileUtils.copy in upload_file to use archive_in from docker-api

### DIFF
--- a/lib/chef/provisioning/docker_driver/docker_transport.rb
+++ b/lib/chef/provisioning/docker_driver/docker_transport.rb
@@ -87,7 +87,11 @@ module DockerDriver
     end
 
     def upload_file(local_path, path)
-      FileUtils.cp(local_path, container_path(path))
+      dir = File.dirname(path)
+      localfile = File.basename(local_path)
+      execute(['mkdir','-p',dir])
+      container.archive_in(local_path, dir, overwrite: true)
+      execute(['mv',dir+"/"+localfile,path])
     end
 
     def make_url_available_to_remote(url)


### PR DESCRIPTION
In [`docker_transport.rb`](https://github.com/chef/chef-provisioning-docker/blob/master/lib/chef/provisioning/docker_driver/docker_transport.rb) "upload_file" is using FileUtils to write a file to container_path, which is defined as "File.join('proc', container.info['State']['Pid'].to_s, 'root', path)".
My CentOS Virtualbox VM uses /var/lib/docker/devicemapper/mnt/'container id'/rootfs as the container mount, so copying to "/proc" results in an error. The "upload_file" is invoked whenever there is the "file" resource used in a recipe.
In [`docker-api`, there's been an update in Jan 2016 which includes an 'archive_in' function](https://github.com/swipely/docker-api/blob/76cfcb98745a8bfca0f647df394cd884bf9dc16a/lib/docker/container.rb#L26). This tars up files on the host and untars it on the destination container. My change just creates the base directory in the container, untars the file there, and renames the file to whatever the user decided on in the "remote_path" parameter of the "file" resource.
