### PR TITLE
avoid overwriting client_key when merging config

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,12 @@ machine 'wario' do
       # if you need to keep stdin open (i.e docker run -i)
       # :keep_stdin_open => true
 
+    },
+    # optional, default timeout is 600
+    docker_connection: {
+     :read_timeout => 1000,
     }
+
 end
 ```
 

--- a/lib/chef/provisioning/docker_driver/driver.rb
+++ b/lib/chef/provisioning/docker_driver/driver.rb
@@ -47,7 +47,7 @@ module DockerDriver
       Docker.logger = Chef::Log
       options = Docker.options.dup || {}
       options.merge!(read_timeout: 600)
-      options.merge!(config.hash_dup) if config
+      options.merge!(config[:docker_connection].hash_dup) if config && config[:docker_connection]
       @connection = Docker::Connection.new(url || Docker.url, options)
     end
 


### PR DESCRIPTION
avoid overwriting client_key when merging config
added docker_connection config
