### PR TITLE
specify machine_options correctly in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,52 +21,54 @@ with_driver 'docker'
 machine 'wario' do
   recipe 'openssh::default'
 
-  machine_options docker_options: {
-    base_image: {
-      name: 'ubuntu',
-      repository: 'ubuntu',
-      tag: '14.04'
+  machine_options(
+    docker_options: {
+      base_image: {
+        name: 'ubuntu',
+        repository: 'ubuntu',
+        tag: '14.04'
+        },
+        :command => '/usr/sbin/sshd -p 8022 -D',
+
+        #ENV (Environment Variables)
+        #Set any env var in the container by using one or more -e flags, even overriding those already defined by the developer with a Dockerfile ENV
+        :env => {
+           "deep" => 'purple',
+           "led" => 'zeppelin'
+        },
+
+        # Ports can be one of two forms:
+        # src_port (string or integer) is a pass-through, i.e 8022 or "9933"
+        # src:dst (string) is a map from src to dst, i.e "8022:8023" maps 8022 externally to 8023 in the container
+
+        # Example (multiple):
+        :ports => [8022, "8023:9000", "9500"],
+
+        # Examples (single):
+        :ports => 1234,
+        :ports => "2345:6789",
+
+        # Volumes can be one of three forms:
+        # src_volume (string) is volume to add to container, i.e. creates new volume inside container at "/tmp"
+        # src:dst (string) mounts host's directory src to container's dst, i.e "/tmp:/tmp1" mounts host's directory /tmp to container's /tmp1
+        # src:dst:mode (string) mounts host's directory src to container's dst with the specified mount option, i.e "/:/rootfs:ro" mounts read-only host's root (/) folder to container's /rootfs
+        # See more details on Docker volumes at https://github.com/docker/docker/blob/master/docs/sources/userguide/dockervolumes.md .
+
+        # Example (single):
+        :volumes => "/tmp",
+
+        # Example (multiple):
+        :volumes => ["/tmp:/tmp", "/:/rootfs:ro"],
+
+        # if you need to keep stdin open (i.e docker run -i)
+        # :keep_stdin_open => true
+
       },
-      :command => '/usr/sbin/sshd -p 8022 -D',
-
-      #ENV (Environment Variables)
-      #Set any env var in the container by using one or more -e flags, even overriding those already defined by the developer with a Dockerfile ENV
-      :env => {
-         "deep" => 'purple',
-         "led" => 'zeppelin'
-      },
-
-      # Ports can be one of two forms:
-      # src_port (string or integer) is a pass-through, i.e 8022 or "9933"
-      # src:dst (string) is a map from src to dst, i.e "8022:8023" maps 8022 externally to 8023 in the container
-
-      # Example (multiple):
-      :ports => [8022, "8023:9000", "9500"],
-
-      # Examples (single):
-      :ports => 1234,
-      :ports => "2345:6789",
-
-      # Volumes can be one of three forms:
-      # src_volume (string) is volume to add to container, i.e. creates new volume inside container at "/tmp"
-      # src:dst (string) mounts host's directory src to container's dst, i.e "/tmp:/tmp1" mounts host's directory /tmp to container's /tmp1
-      # src:dst:mode (string) mounts host's directory src to container's dst with the specified mount option, i.e "/:/rootfs:ro" mounts read-only host's root (/) folder to container's /rootfs
-      # See more details on Docker volumes at https://github.com/docker/docker/blob/master/docs/sources/userguide/dockervolumes.md .
-
-      # Example (single):
-      :volumes => "/tmp",
-
-      # Example (multiple):
-      :volumes => ["/tmp:/tmp", "/:/rootfs:ro"],
-
-      # if you need to keep stdin open (i.e docker run -i)
-      # :keep_stdin_open => true
-
-    },
-    # optional, default timeout is 600
-    docker_connection: {
-     :read_timeout => 1000,
-    }
+      # optional, default timeout is 600
+      docker_connection: {
+       :read_timeout => 1000,
+      }
+  )
 
 end
 ```
@@ -81,22 +83,26 @@ require 'chef/provisioning/docker_driver'
 machine_image 'ssh_server' do
   recipe 'openssh'
 
-  machine_options :docker_options => {
+  machine_options(
+    :docker_options => {
       :base_image => {
           :name => 'ubuntu',
           :repository => 'ubuntu',
           :tag => '14.04'
       }
-  }
+    }
+  )
 end
 
 machine 'ssh00' do
   from_image 'ssh_server'
 
-  machine_options :docker_options => {
+  machine_options(
+    :docker_options => {
       :command => '/usr/sbin/sshd -D -o UsePAM=no -o UsePrivilegeSeparation=no -o PidFile=/tmp/sshd.pid',
       :ports => [22]
-  }
+    }
+  )
 end
 ```
 


### PR DESCRIPTION
the machine_options in the README only work until you need to add more machine options, and then it leads to really confusing issues that are due to using the incorrect machine_options syntax (eg. https://github.com/chef/chef-provisioning/issues/481) - this attempts to correct the documentation
