### PR TITLE
ability to override default proxy gateway

### DIFF
--- a/lib/chef/provisioning/docker_driver/docker_transport.rb
+++ b/lib/chef/provisioning/docker_driver/docker_transport.rb
@@ -128,7 +128,7 @@ module DockerDriver
 
             old_uri = uri.dup
 
-            uri.host = $1
+            uri.host = ENV["PROXY_HOST_OVERRIDE"] ?  ENV["PROXY_HOST_OVERRIDE"] : $1
 
             if !@proxy_thread
               # Listen to docker instances only, and forward to localhost


### PR DESCRIPTION
potential backward compatible fix for https://github.com/chef/chef-provisioning-docker/issues/93

This is a problem that seems to happen only with docker for mac (not toolbox). When it can't use the ssh transport it falls back on the proxy mechanism.  By default this proxy tries to forward localhost to the default gateway.  Unfortunately this doesn't work on docker mac.  What does work is either connecting to the public IP of the mac, or creating a loopback alias as described [here](https://docs.docker.com/docker-for-mac/networking/#use-cases-and-workarounds) in the section "I want to connect from a container to a service on the host".  Both of these methods mean we need to force a new IP for the proxy to forward to, and this PR allows an environment variable to be set to do that.