### PR TITLE
Remove testing on 2.1.9 / require provisioning 2.0+

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,6 @@ branches:
   only:
     - master
 rvm:
-  - 2.1.9
   - 2.2.5
   - 2.3.1
 script: bundle exec rake build

--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,2 @@
 source "https://rubygems.org"
 gemspec
-
-gem "chef", git: "https://github.com/chef/chef" if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new("2.2.2") # until stable 12.14 is released (won't load new cheffish and such otherwise)

--- a/chef-provisioning-docker.gemspec
+++ b/chef-provisioning-docker.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |s|
   s.homepage = 'https://github.com/chef/chef-provisioning-docker'
 
   s.add_dependency 'chef'
-  s.add_dependency 'chef-provisioning', '>= 1.0', '< 3.0'
+  s.add_dependency 'chef-provisioning', '>= 2.0', '< 3.0'
   s.add_dependency 'docker-api', '~> 1.26', '>= 1.26.2'
   s.add_dependency 'minitar'
   s.add_dependency 'sys-proctable'


### PR DESCRIPTION
The world seems to require Ruby 2.2+. It’s not just chef with the rack dep. We have deps on active support as well.

Signed-off-by: Tim Smith <tsmith@chef.io>